### PR TITLE
List all reports

### DIFF
--- a/app/api/BackendApi.ts
+++ b/app/api/BackendApi.ts
@@ -17,6 +17,9 @@ import GetBiopsyResult from './graphql/queries/getBiopsyResult.graphql';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import GetRelevantReports from './graphql/queries/getRelevantReports.graphql';
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+import ListReports from './graphql/queries/ListReports.graphql';
 import {ApolloQueryResult} from 'apollo-client';
 import client from './AppsyncClient';
 import {IBiopsyResult, IGeneInfo, IIngestionProgress, IRelevantReport} from '../types';
@@ -63,6 +66,14 @@ export default class BackendApi extends BaseApi {
 			},
 		});
 		return status.data.getRelevantReports;
+	}
+
+	public static async listReports(): Promise<IBiopsyResult[]> {
+		const status: ApolloQueryResult<{ listReports: [IBiopsyResult] }> = await client.query({
+			query: ListReports,
+			fetchPolicy: 'network-only',
+		});
+		return status.data.listReports;
 	}
 
 	// MUTATIONS

--- a/app/api/BackendApi.ts
+++ b/app/api/BackendApi.ts
@@ -19,7 +19,7 @@ import GetBiopsyResult from './graphql/queries/getBiopsyResult.graphql';
 import GetRelevantReports from './graphql/queries/getRelevantReports.graphql';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
-import ListReports from './graphql/queries/ListReports.graphql';
+import ListReports from './graphql/queries/listReports.graphql';
 import {ApolloQueryResult} from 'apollo-client';
 import client from './AppsyncClient';
 import {IBiopsyResult, IGeneInfo, IIngestionProgress, IRelevantReport} from '../types';

--- a/app/api/BackendApi.ts
+++ b/app/api/BackendApi.ts
@@ -68,12 +68,16 @@ export default class BackendApi extends BaseApi {
 		return status.data.getRelevantReports;
 	}
 
-	public static async listReports(): Promise<IBiopsyResult[]> {
+	public static async listUniqueReports(): Promise<IBiopsyResult[]> {
 		const status: ApolloQueryResult<{ listReports: [IBiopsyResult] }> = await client.query({
 			query: ListReports,
 			fetchPolicy: 'network-only',
 		});
-		return status.data.listReports;
+
+		const output = status.data.listReports;
+
+		const map = new Map(output.map(res => [res.blockId, res]));
+		return [...map.values()];
 	}
 
 	// MUTATIONS

--- a/app/api/graphql/queries/listReports.graphql
+++ b/app/api/graphql/queries/listReports.graphql
@@ -1,0 +1,6 @@
+query ListReports {
+    listReports {
+        id
+        blockId
+    }
+}

--- a/tests/backend/api.graphql
+++ b/tests/backend/api.graphql
@@ -56,6 +56,10 @@ type Query {
     Returns relevant biopsy results based on coding region change
     """
     getRelevantReports(codingRegionChange: [String]!): [RelevantReport]!
+    """
+    Lists all reports
+    """
+    listReports: [BiopsyResult]!
 }
 
 """

--- a/tests/backend/handler.js
+++ b/tests/backend/handler.js
@@ -27,6 +27,9 @@ const resolverMap = {
 		getRelevantReport() {
 			return readResponse('relevantReport');
 		},
+		listReports() {
+			return [{id: 'id1', blockId: 'asdfasdfasdf'}, {id:'id2', blockId: 'asdfaserfaefhekj'}];
+		},
 	},
 	Subscription: {
 		onProgressUpdate() {


### PR DESCRIPTION
- adding a backendApi call to list all request
- only returning id and blockId 
- also added a mock endpoint, just to keep it consistent